### PR TITLE
Fix warning about explicit `dyn` missing

### DIFF
--- a/diamond-api/src/find.rs
+++ b/diamond-api/src/find.rs
@@ -85,7 +85,7 @@ pub struct FindQuery {
 
 impl FromRequest for FindQuery {
     type Error = Error;
-    type Future = Box<Future<Item = Self, Error = Error>>;
+    type Future = Box<dyn Future<Item = Self, Error = Error>>;
     type Config = ();
 
     fn from_request(req: &HttpRequest, payload: &mut dev::Payload) -> Self::Future {

--- a/diamond-api/src/render.rs
+++ b/diamond-api/src/render.rs
@@ -48,7 +48,7 @@ impl FromStr for RenderQuery {
 
 impl FromRequest for RenderQuery {
     type Error = Error;
-    type Future = Box<Future<Item = Self, Error = Error>>;
+    type Future = Box<dyn Future<Item = Self, Error = Error>>;
     type Config = ();
 
     fn from_request(req: &HttpRequest, payload: &mut dev::Payload) -> Self::Future {


### PR DESCRIPTION
```
$ rustc -V
rustc 1.38.0-nightly (4bb6b4a5e 2019-07-11)
```

```
$ cargo build
<snip>
warning: trait objects without an explicit `dyn` are deprecated
  --> diamond-api/src/find.rs:88:23
   |
88 |     type Future = Box<Future<Item = Self, Error = Error>>;
   |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use `dyn`: `dyn Future<Item = Self, Error = Error>`
   |
   = note: #[warn(bare_trait_objects)] on by default

warning: trait objects without an explicit `dyn` are deprecated
  --> diamond-api/src/render.rs:51:23
   |
51 |     type Future = Box<Future<Item = Self, Error = Error>>;
   |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use `dyn`: `dyn Future<Item = Self, Error = Error>`
```